### PR TITLE
Update README to remove Sirv references

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,6 @@ Via CLI:
 npm run build
 ```
 
-Run the latest changes with `npm run start`. This app uses [sirv](https://github.com/lukeed/sirv), which is included in the dependencies, so that the app will work when you deploy to platforms like [Heroku](https://heroku.com).
+Run the latest changes with `npm run start`.
 
 


### PR DESCRIPTION
This app no longer uses sirv-cli, and as such all references should be
removed from the README.